### PR TITLE
config.json path description in docker-compose.yml is fixed.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,59 +14,59 @@ services:
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile2:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile3:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile4:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile5:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile6:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile7:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile8:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile9:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
   tile10:
     image: maptiler/tileserver-gl
     volumes:
     - .:/data
     restart: always
-    command: -p 8080 --verbose -c /data/config.json
+    command: -p 8080 --verbose -c config.json
 


### PR DESCRIPTION
In order to make it work, the `config.json` file at the project root directory should be used.